### PR TITLE
Add CI and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+---
+name: CI/CD
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  shell-lint:
+    permissions:
+      contents: read
+    uses: dceoy/gh-actions-for-devops/.github/workflows/shell-lint.yml@main   # zizmor: ignore[unpinned-uses]
+    with:
+      search-path: .
+      file-names: print-github-*
+  dependabot-auto-merge:
+    if: >
+      github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      checks: read
+      statuses: read
+    uses: dceoy/gh-actions-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      unconditional: true
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ print-github-tags
 
 Tiny command to fetch repository tags or releases from GitHub
 
+[![CI/CD](https://github.com/dceoy/print-github-tags/actions/workflows/ci.yml/badge.svg)](https://github.com/dceoy/print-github-tags/actions/workflows/ci.yml)
+
 Installation
 ------------
 


### PR DESCRIPTION
## Summary
- Add a reusable GitHub Actions CI workflow for shell linting and Dependabot auto-merge.
- Add Dependabot configuration for GitHub Actions updates.
- Add the CI badge to the README.

## Test plan
- Not run locally; configuration-only change.


Made with [Cursor](https://cursor.com)