### PR TITLE
Harden CLI without adding dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tiny command to fetch repository tags or releases from GitHub
 
 ## Installation
 
-This command depends on curl.
+This command depends on curl. It does not require jq or other non-standard JSON parsers.
 
 ```sh
 $ git clone https://github.com/dceoy/print-github-tags.git
@@ -39,6 +39,12 @@ Fetch the URL for the source code of the latest release.
 $ print-github-tags --release --latest --tar curl/curl
 ```
 
+## Notes
+
+- Tag and release list commands request up to 100 items from the GitHub API.
+- `--latest --release` uses GitHub's latest-release API.
+- `--latest` without `--release` prints the first tag returned by the GitHub tags API; it does not perform semantic-version sorting.
+
 ## Usage
 
 ```sh
@@ -54,7 +60,7 @@ Options:
   -h, --help        Print usage
   -v, --version     Print version information
   --release         Print only releases
-  --latest          Print a latest tag or release
+  --latest          Print the latest release, or the first tag returned by the GitHub API
   --tar             Print tar file URLs (.tar.gz)
   --zip             Print zip file URLs (.zip)
 

--- a/print-github-tags
+++ b/print-github-tags
@@ -1,22 +1,6 @@
 #!/usr/bin/env bash
 #
 # Tiny command to fetch repository tags or releases from GitHub
-#
-# Usage:
-#   print-github-tags -h|--help
-#   print-github-tags -v|--version
-#   print-github-tags [--release] [--latest] [--tar|--zip] <owner>/<repo>
-#
-# Options:
-#   -h, --help        Print usage
-#   -v, --version     Print version information
-#   --release         Print only releases
-#   --latest          Print the latest release, or the first tag returned by the GitHub API
-#   --tar             Print tar file URLs (.tar.gz)
-#   --zip             Print zip file URLs (.zip)
-#
-# Example:
-#   $ print-github-tags --release --latest --tar curl/curl
 
 set -Eeuo pipefail
 

--- a/print-github-tags
+++ b/print-github-tags
@@ -11,40 +11,85 @@
 #   -h, --help        Print usage
 #   -v, --version     Print version information
 #   --release         Print only releases
-#   --latest          Print a latest tag or release
+#   --latest          Print the latest release, or the first tag returned by the GitHub API
 #   --tar             Print tar file URLs (.tar.gz)
 #   --zip             Print zip file URLs (.zip)
 #
 # Example:
 #   $ print-github-tags --release --latest --tar curl/curl
 
-set -e
+set -Eeuo pipefail
 
-[[ "${1}" = '--debug' ]] && set -x && shift 1
+[[ "${1:-}" = '--debug' ]] && set -x && shift 1
 
 COMMAND_NAME='print-github-tags'
-COMMAND_VERSION='v0.2.1'
-COMMAND_PATH=$(realpath "${0}")
+COMMAND_VERSION='v0.2.2'
 RELEASE=0
 LATEST=0
 TAR=0
 ZIP=0
 OWNER_REPO=''
 
-function print_version {
+print_version() {
   echo "${COMMAND_NAME}: ${COMMAND_VERSION}"
 }
 
-function print_usage {
-  sed -ne '1,2d; /^#/!q; s/^#$/# /; s/^# //p;' "${COMMAND_PATH}"
+print_usage() {
+  cat <<'USAGE'
+Tiny command to fetch repository tags or releases from GitHub
+
+Usage:
+  print-github-tags -h|--help
+  print-github-tags -v|--version
+  print-github-tags [--release] [--latest] [--tar|--zip] <owner>/<repo>
+
+Options:
+  -h, --help        Print usage
+  -v, --version     Print version information
+  --release         Print only releases
+  --latest          Print the latest release, or the first tag returned by the GitHub API
+  --tar             Print tar file URLs (.tar.gz)
+  --zip             Print zip file URLs (.zip)
+
+Example:
+  $ print-github-tags --release --latest --tar curl/curl
+USAGE
 }
 
-function abort {
+abort() {
   echo "${COMMAND_NAME}: ${*}" >&2
   exit 1
 }
 
-while [[ -n "${1}" ]]; do
+is_valid_owner_repo() {
+  local owner_repo="${1}"
+  local owner repo
+
+  [[ "${owner_repo}" =~ ^[A-Za-z0-9-]+/[A-Za-z0-9._-]+$ ]] || return 1
+
+  owner="${owner_repo%%/*}"
+  repo="${owner_repo#*/}"
+
+  [[ "${owner}" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
+  [[ "${repo}" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+}
+
+print_items() {
+  local item
+
+  while IFS= read -r item; do
+    [[ -n "${item}" ]] || continue
+    if [[ ${TAR} -eq 1 ]]; then
+      printf 'https://github.com/%s/archive/%s.tar.gz\n' "${OWNER_REPO}" "${item}"
+    elif [[ ${ZIP} -eq 1 ]]; then
+      printf 'https://github.com/%s/archive/%s.zip\n' "${OWNER_REPO}" "${item}"
+    else
+      printf '%s\n' "${item}"
+    fi
+  done
+}
+
+while [[ $# -gt 0 ]]; do
   case "${1}" in
     '-v' | '--version' )
       print_version && exit 0
@@ -59,26 +104,26 @@ while [[ -n "${1}" ]]; do
       LATEST=1 && shift 1
       ;;
     '--tar' )
-      [[ ${ZIP} -ne 0 ]] && print_usage && exit 1
+      [[ ${ZIP} -ne 0 ]] && abort '--tar and --zip are mutually exclusive'
       TAR=1 && shift 1
       ;;
     '--zip' )
-      [[ ${TAR} -ne 0 ]] && print_usage && exit 1
+      [[ ${TAR} -ne 0 ]] && abort '--tar and --zip are mutually exclusive'
       ZIP=1 && shift 1
       ;;
     * )
       if [[ "${1:0:1}" = '-' ]]; then
         abort "invalid option \`${1}\`"
-      elif [[ -z "${OWNER_REPO}" ]] && [[ "${1}" =~ ^[^/]+/[^/]+$ ]]; then
+      elif [[ -n "${OWNER_REPO}" ]]; then
+        abort "unexpected argument \`${1}\`"
+      elif is_valid_owner_repo "${1}"; then
         OWNER_REPO="${1}" && shift 1
       else
-        print_usage && exit 1
+        abort "invalid repository format \`${1}\`; expected <owner>/<repo>"
       fi
       ;;
   esac
 done
-
-set -u
 
 [[ -z "${OWNER_REPO}" ]] && print_usage && exit 1
 
@@ -86,24 +131,19 @@ if [[ ${RELEASE} -eq 1 ]]; then
   if [[ ${LATEST} -eq 1 ]]; then
     API_URL="https://api.github.com/repos/${OWNER_REPO}/releases/latest"
   else
-    API_URL="https://api.github.com/repos/${OWNER_REPO}/releases"
+    API_URL="https://api.github.com/repos/${OWNER_REPO}/releases?per_page=100"
   fi
   KEY='tag_name'
 else
-  API_URL="https://api.github.com/repos/${OWNER_REPO}/tags"
+  API_URL="https://api.github.com/repos/${OWNER_REPO}/tags?per_page=100"
   KEY='name'
 fi
 
-CMD="curl -sS ${API_URL} | grep '\"${KEY}\":' | cut -d '\"' -f 4"
+RESPONSE=$(curl -fsSL "${API_URL}")
+ITEMS=$(printf '%s\n' "${RESPONSE}" | grep "\"${KEY}\":" | cut -d '"' -f 4 || true)
 
 if [[ ${LATEST} -eq 1 ]]; then
-  CMD="${CMD} | head -1"
+  ITEMS=$(printf '%s\n' "${ITEMS}" | head -n 1)
 fi
 
-if [[ ${TAR} -eq 1 ]]; then
-  CMD="${CMD} | xargs -I {} echo 'https://github.com/${OWNER_REPO}/archive/{}.tar.gz'"
-elif [[ ${ZIP} -eq 1 ]]; then
-  CMD="${CMD} | xargs -I {} echo 'https://github.com/${OWNER_REPO}/archive/{}.zip'"
-fi
-
-bash -c "${CMD}"
+printf '%s\n' "${ITEMS}" | print_items

--- a/print-github-tags
+++ b/print-github-tags
@@ -23,7 +23,7 @@ set -Eeuo pipefail
 [[ "${1:-}" = '--debug' ]] && set -x && shift 1
 
 COMMAND_NAME='print-github-tags'
-COMMAND_VERSION='v0.2.2'
+COMMAND_VERSION='v1.0.0'
 RELEASE=0
 LATEST=0
 TAR=0

--- a/test/print-github-tags.bats
+++ b/test/print-github-tags.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  SCRIPT="${REPO_ROOT}/print-github-tags"
+  TEST_BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${TEST_BIN}"
+  export PATH="${TEST_BIN}:${PATH}"
+}
+
+mock_curl() {
+  cat > "${TEST_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=''
+for arg in "$@"; do
+  url="${arg}"
+done
+
+case "${url}" in
+  'https://api.github.com/repos/curl/curl/tags?per_page=100' )
+    cat <<'JSON'
+[
+  {
+    "name": "curl-8_14_1",
+    "zipball_url": "https://api.github.com/repos/curl/curl/zipball/refs/tags/curl-8_14_1",
+    "tarball_url": "https://api.github.com/repos/curl/curl/tarball/refs/tags/curl-8_14_1"
+  },
+  {
+    "name": "curl-8_14_0",
+    "zipball_url": "https://api.github.com/repos/curl/curl/zipball/refs/tags/curl-8_14_0",
+    "tarball_url": "https://api.github.com/repos/curl/curl/tarball/refs/tags/curl-8_14_0"
+  }
+]
+JSON
+    ;;
+  'https://api.github.com/repos/curl/curl/releases?per_page=100' )
+    cat <<'JSON'
+[
+  {
+    "tag_name": "curl-8_14_1",
+    "name": "curl 8.14.1"
+  },
+  {
+    "tag_name": "curl-8_14_0",
+    "name": "curl 8.14.0"
+  }
+]
+JSON
+    ;;
+  'https://api.github.com/repos/curl/curl/releases/latest' )
+    cat <<'JSON'
+{
+  "tag_name": "curl-8_14_1",
+  "name": "curl 8.14.1"
+}
+JSON
+    ;;
+  * )
+    echo "unexpected URL: ${url}" >&2
+    exit 64
+    ;;
+esac
+MOCK
+  chmod +x "${TEST_BIN}/curl"
+}
+
+@test "prints version" {
+  run "${SCRIPT}" --version
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = 'print-github-tags: v0.2.2' ]
+}
+
+@test "prints usage" {
+  run "${SCRIPT}" --help
+
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *'Usage:'* ]]
+  [[ "${output}" == *'--latest          Print the latest release, or the first tag returned by the GitHub API'* ]]
+}
+
+@test "rejects missing repository" {
+  run "${SCRIPT}"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'Usage:'* ]]
+}
+
+@test "rejects invalid repository format" {
+  run "${SCRIPT}" 'curl/curl;echo injected'
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'invalid repository format'* ]]
+}
+
+@test "rejects mutually exclusive archive formats" {
+  run "${SCRIPT}" --tar --zip curl/curl
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'--tar and --zip are mutually exclusive'* ]]
+}
+
+@test "prints tags from GitHub API response" {
+  mock_curl
+
+  run "${SCRIPT}" curl/curl
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = $'curl-8_14_1\ncurl-8_14_0' ]
+}
+
+@test "prints releases from GitHub API response" {
+  mock_curl
+
+  run "${SCRIPT}" --release curl/curl
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = $'curl-8_14_1\ncurl-8_14_0' ]
+}
+
+@test "prints archive URL for the first tag returned by the tags API" {
+  mock_curl
+
+  run "${SCRIPT}" --latest --tar curl/curl
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = 'https://github.com/curl/curl/archive/curl-8_14_1.tar.gz' ]
+}
+
+@test "prints archive URL for the latest release" {
+  mock_curl
+
+  run "${SCRIPT}" --release --latest --zip curl/curl
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = 'https://github.com/curl/curl/archive/curl-8_14_1.zip' ]
+}

--- a/test/print-github-tags.bats
+++ b/test/print-github-tags.bats
@@ -70,7 +70,7 @@ MOCK
   run "${SCRIPT}" --version
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = 'print-github-tags: v0.2.2' ]
+  [ "${output}" = 'print-github-tags: v1.0.0' ]
 }
 
 @test "prints usage" {

--- a/test/print-github-tags.bats
+++ b/test/print-github-tags.bats
@@ -8,6 +8,15 @@ setup() {
   export PATH="${TEST_BIN}:${PATH}"
 }
 
+expected_version_output() {
+  local command_name command_version
+
+  command_name="$(grep '^COMMAND_NAME=' "${SCRIPT}" | cut -d "'" -f 2)"
+  command_version="$(grep '^COMMAND_VERSION=' "${SCRIPT}" | cut -d "'" -f 2)"
+
+  printf '%s: %s\n' "${command_name}" "${command_version}"
+}
+
 mock_curl() {
   cat > "${TEST_BIN}/curl" <<'MOCK'
 #!/usr/bin/env bash
@@ -70,7 +79,7 @@ MOCK
   run "${SCRIPT}" --version
 
   [ "${status}" -eq 0 ]
-  [ "${output}" = 'print-github-tags: v1.0.0' ]
+  [ "${output}" = "$(expected_version_output)" ]
 }
 
 @test "prints usage" {


### PR DESCRIPTION
## Summary
- bump the CLI version to `v1.0.0`
- remove dynamic command construction and `bash -c` execution
- enable stricter shell behavior with `set -Eeuo pipefail`
- validate `<owner>/<repo>` more narrowly before building GitHub API URLs
- use `curl -fsSL` so HTTP failures fail the command
- remove `realpath` usage by replacing self-parsed usage with a heredoc
- request up to 100 tags/releases and document the `--latest` semantics
- add Bats tests that mock `curl` and cover CLI behavior without live GitHub API calls

## Notes
- No `jq` or other install-time dependency is introduced.
- JSON extraction remains intentionally lightweight with `grep`/`cut` to preserve the minimal dependency model.
- The Bats tests use a local mock `curl` executable so they are deterministic and offline-friendly.

## Validation
- `bash -n print-github-tags`
- `print-github-tags --version`
- `print-github-tags --help`
- invalid repository format smoke test
- mocked `curl` response for tag listing and `--latest --tar` output
- `bats test/print-github-tags.bats`